### PR TITLE
Fixed default lists being added when generating new board

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you're here to help contribute, here are a few steps on how to set this exten
 1. Make sure you have enabled developer mode in Chrome at `chrome://extensions`
 2. Clone this repo, and press 'Load unpacked' to load this extension
 3. Go to key.js and replace the field of `api_key`. It can found out at https://trello.com/app-key
-4. Add the Chrome extension ID to Allowed origins section in the same Trello page
+4. Add the Chrome extension ID to Allowed origins section in the same Trello page (eg. `chrome-extension://okpdemdmpglaapjpbdphmfhlfjbilbpc`)
 
 That's it! You should be able to use the extension and see your cards being saved on Trello. 
 Note: If you skip the 4th step, you will recieve an invalid redirect error. 

--- a/popup.js
+++ b/popup.js
@@ -36,7 +36,7 @@ document.addEventListener('DOMContentLoaded', function () { // this function  st
             document.getElementById("create_board").innerHTML = "creating...";
 
             // create a new board and add lists to it
-            Trello.post(`/boards?token=${token}&name=Full time Hunt`)
+            Trello.post(`/boards?token=${token}&name=Full time Hunt&defaultLists=false`)
                 .then(async (response) => {
                     localStorage.setItem('board_id', response.id);
                     board_id = localStorage.getItem('board_id');


### PR DESCRIPTION
For issue #25 

It looks like if we post a new board with the parameters `defaultLists=false`, the placeholder lists aren't created to begin with.

I also had a bit of trouble setting up the extension because I didn't know what was meant by "Add the Chrome extension ID to Allowed origins section in the same Trello page", so I added an example so future contributors know what format it expects.

Reference: https://developer.atlassian.com/cloud/trello/rest/api-group-boards/#api-boards-post