### PR TITLE
Add functionality to set up an existing board

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -52,8 +52,24 @@
         <p><small><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=ZBR894KSWNJPS&currency_code=CAD" target="_blank" class="text-dark">Donate</a></small></p>
     </div>
     <div class="container py-2" id="board_missing" style="display: none;">
-        <p>Looks like you don't have a board set up. Click the button below and we'll create for you! Once created, you can check it at <a href="https://trello.com/" target="_blank">Trello's website</a></p>
-        <button class="btn btn-success" id="create_board">Create</button>
+        <p>Looks like you don't have a board set up. We can create one for you or you can choose one of your existing boards.
+            If you choose to create a new one, you can check it at <a href="https://trello.com/" target="_blank">Trello's website</a> once created
+        </p>
+        <form>
+            <div class="form-check form-check-inline mb-2">
+                <input class="form-check-input" type="radio" id="create_board" name="board_choice" value="create_board" checked>
+                <label class="form-check-label" for="create_board">Create board</label>
+            </div>
+            <div class="form-check form-check-inline mb-2">
+                <input class="form-check-input" type="radio" id="use_existing_board" name="board_choice" value="use_existing_board">
+                <label class="form-check-label" for="use_existing_board">Use my board</label><br>
+            </div>
+            <div class="form-group" id="board_url_div" style="display: none;">
+                <input type="url" class="form-control mt-2 mb-2" id="board_url" placeholder="https://trello.com/b/my_board_id" autocomplete="off">
+                <span id="board_url_error" class="text-danger"></span>
+            </div>
+        </form>
+        <button class="btn btn-success" id="set_board">Done</button>
     </div>
 
     <!-- successfully posted alert -->

--- a/popup.js
+++ b/popup.js
@@ -5,6 +5,11 @@ document.addEventListener('DOMContentLoaded', function () { // this function  st
     var token = localStorage.getItem('trello_token');
     var board_id = localStorage.getItem('board_id');
     var create_board = document.getElementById("create_board");
+    var use_existing_board = document.getElementById("use_existing_board");
+    var board_url = document.getElementById("board_url");
+    var board_url_div = document.getElementById("board_url_div");
+    var set_board = document.getElementById("set_board");
+    var board_url_error = document.getElementById("board_url_error");
     var board_missing_div = document.getElementById('board_missing');
     var oauth_ok_div = document.getElementById('oauth_ok');
     var checkPageButton = document.getElementById('checkPage');
@@ -12,6 +17,16 @@ document.addEventListener('DOMContentLoaded', function () { // this function  st
     const monthNames = ["January", "February", "March", "April", "May", "June",
         "July", "August", "September", "October", "November", "December"
     ];
+    const trelloBoardUrlPattern = /https\:\/\/trello\.com\/b\/(.{8})(\/.*)?$/;
+
+    create_board.addEventListener('click', function () {
+        board_url_div.style.display = "none";
+        clear_board_url_data();
+    });
+
+    use_existing_board.addEventListener('click', function () {
+        board_url_div.style.display = "block";
+    });
 
     // if token doesn't exist, go to options page and make the user authorize it
     if (!token) {
@@ -19,37 +34,83 @@ document.addEventListener('DOMContentLoaded', function () { // this function  st
         sendResponse();
         return true;
     }
-    // if board does not exist, create one and add it to local storage
+    // if board does not exist, set up one and add it to local storage
     else if (!board_id) {
-        board_create_function();
+        board_set_up_function();
     }
     else {
         working();
     }
 
-    function board_create_function() {
+    function board_set_up_function() {
         board_missing_div.style.display = 'block';
         oauth_ok_div.style.display = 'none';
 
-        create_board.addEventListener('click', function () {
+        set_board.addEventListener('click', function () {
+            document.getElementById("set_board").innerHTML = "preparing your board...";
 
-            document.getElementById("create_board").innerHTML = "creating...";
+            if (create_board.checked) {
+                board_create_function();
+            } else {
+                board_use_existing_function();
+            }
+        });
+    }
 
-            // create a new board and add lists to it
-            Trello.post(`/boards?token=${token}&name=Full time Hunt&defaultLists=false`)
-                .then(async (response) => {
+    function board_create_function() {
+        Trello.post(`/boards?token=${token}&name=Full time Hunt&defaultLists=false`)
+            .then(async (response) => {
+                localStorage.setItem('board_id', response.id);
+                board_id = localStorage.getItem('board_id');
+                Trello.post(`/lists?token=${token}&name=Offer&idBoard=${board_id}`);
+                await Trello.post(`/lists?token=${token}&name=Reject&idBoard=${board_id}`);
+                await Trello.post(`/lists?token=${token}&name=InProgress&idBoard=${board_id}`);
+                await Trello.post(`/lists?token=${token}&name=Applied&idBoard=${board_id}`);
+                await Trello.post(`/lists?token=${token}&name=Wishlist&idBoard=${board_id}`);
+                document.getElementById("set_board").innerHTML = "Done!";
+                working();
+            })
+            .catch(error => console.log(error));
+    }
+
+    function board_use_existing_function() {
+        const userBoardId = extract_board_id(board_url.value);
+
+        if (userBoardId) {
+            Trello.get(`/boards/${userBoardId}?token=${token}`)
+                .then(response => {
                     localStorage.setItem('board_id', response.id);
                     board_id = localStorage.getItem('board_id');
-                    Trello.post(`/lists?token=${token}&name=Offer&idBoard=${board_id}`);
-                    await Trello.post(`/lists?token=${token}&name=Reject&idBoard=${board_id}`);
-                    await Trello.post(`/lists?token=${token}&name=InProgress&idBoard=${board_id}`);
-                    await Trello.post(`/lists?token=${token}&name=Applied&idBoard=${board_id}`);
-                    await Trello.post(`/lists?token=${token}&name=Wishlist&idBoard=${board_id}`);
-                    document.getElementById("create_board").innerHTML = "Done!";
+                    document.getElementById("set_board").innerHTML = "Done!";
                     working();
                 })
-                .catch(error => console.log(error));
-        });
+                .catch(error => {
+                    show_board_url_error("Could not find your board");
+                });
+        } else {
+            show_board_url_error("Invalid URL");
+        }
+    }
+
+    function extract_board_id(boardUrl) {
+        let userBoardId = null;
+        const boardUrlMatcher = boardUrl.match(trelloBoardUrlPattern);
+        if (boardUrl && boardUrlMatcher) {
+            userBoardId = boardUrlMatcher[1];
+        }
+        return userBoardId;
+    }
+
+    function show_board_url_error(message) {
+        board_url_error.innerHTML = message;
+        board_url.classList.add("is-invalid");
+        document.getElementById("set_board").innerHTML = "Done";
+    }
+
+    function clear_board_url_data() {
+        board_url_error.innerHTML = '';
+        board_url.classList.remove("is-invalid");
+        board_url.value = ''
     }
 
     function working() {
@@ -81,7 +142,7 @@ document.addEventListener('DOMContentLoaded', function () { // this function  st
             })
             .catch(err => {
                 console.log("user has deleted the board manually.");
-                board_create_function();
+                board_set_up_function();
             });
         
         // Populating Fields
@@ -141,7 +202,7 @@ document.addEventListener('DOMContentLoaded', function () { // this function  st
                 Trello.post(`/cards?key=${APP_KEY}&token=${token}&idList=${idList}&name=${data_company}&desc=${description}`)
                     .then(response => {
                         console.log("result", response);
-                        if (response.status == 400 || response.status == 401) {
+                        if (response.status == 400 || response.status == 401 || response.status == 403) {
                             console.log("error error");
                             // now change divs
                             let abc = document.getElementById('post_fail');


### PR DESCRIPTION
It is now possible to choose between creating a board and using an existing board. I added screenshots of the layout.
Issue #18 
When "Create board" is selected:
![create](https://user-images.githubusercontent.com/18334788/96639169-fa5e4100-1329-11eb-8a8f-a2dae5abc03b.PNG)
When "Use my board" is selected - the placeholder shows the URL format expected for the board id:
![use](https://user-images.githubusercontent.com/18334788/96639246-1a8e0000-132a-11eb-9409-ca061e743edd.PNG)
A valid Trello board URL will look like this:
![valid_board](https://user-images.githubusercontent.com/18334788/96639487-7193d500-132a-11eb-9e91-b2f4938d175a.PNG)
If an invalid URL is inserted (empty or does not match the Trello board URL regex):
![invalid](https://user-images.githubusercontent.com/18334788/96639355-47daae00-132a-11eb-893b-daa10d2247d0.PNG)
If the URL is valid, but the GET request fails (e.g. the board does not exist):
![not_found](https://user-images.githubusercontent.com/18334788/96639435-6345b900-132a-11eb-835c-a00cdae99322.PNG)

One assumption I made was that when the user chooses to use an existing board, he will already have some lists that he wants to use. So I did not create the lists which are created in the case of a new board (Offer, Reject, InProgress etc).

I will wait for your feedback on this 😄 